### PR TITLE
Fix: Remove sshnoprompt configuration

### DIFF
--- a/src/sagemaker/git_utils.py
+++ b/src/sagemaker/git_utils.py
@@ -278,13 +278,7 @@ def _run_clone_command(repo_url, dest_dir):
         my_env["GIT_TERMINAL_PROMPT"] = "0"
         subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
     elif repo_url.startswith("git@"):
-        with tempfile.NamedTemporaryFile() as sshnoprompt:
-            write_pipe = open(sshnoprompt.name, "w")
-            write_pipe.write("ssh -oBatchMode=yes $@")
-            write_pipe.close()
-            os.chmod(sshnoprompt.name, 0o511)
-            my_env["GIT_SSH"] = sshnoprompt.name
-            subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
+        subprocess.check_call(["git", "clone", repo_url, dest_dir], env=my_env)
 
 
 def _insert_token_to_repo_url(url, token):


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/sagemaker-python-sdk/issues/2442

*Description of changes:*

Currently, users cannot authenticate using SSH in training jobs, which
limits the ways users can launch training and processing jobs. 
This PR removes the entire `sshnoprompt` dialogue, allowing developers to
configure SSH configuration independently of the Sagemaker SDK.

*Testing done:*

- local testing with ssh configuration

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backword compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
